### PR TITLE
fix(core): use toFixed to prevent formatting to scientific notation

### DIFF
--- a/apps/server/src/defichain/services/WhaleWalletService.ts
+++ b/apps/server/src/defichain/services/WhaleWalletService.ts
@@ -80,7 +80,7 @@ export class WhaleWalletService {
 
       // Successful verification, proceed to sign the claim
       const fee = new BigNumber(verify.amount).multipliedBy(this.configService.getOrThrow('defichain.transferFee'));
-      const amountLessFee = BigNumber.max(verify.amount.minus(fee), 0).toString();
+      const amountLessFee = BigNumber.max(verify.amount.minus(fee), 0).toFixed();
 
       const claim = await this.evmTransactionService.signClaim({
         receiverAddress: verify.ethReceiverAddress,

--- a/apps/web/src/components/BridgeForm.tsx
+++ b/apps/web/src/components/BridgeForm.tsx
@@ -142,7 +142,8 @@ export default function BridgeForm({
   const onInputChange = (value: string): void => {
     // regex to allow only number
     const re = /^\d*\.?\d*$/;
-    if (value === "" || re.test(value)) {
+    const maxDp = /^\d*(\.\d{0,6})?$/;
+    if (value === "" || (re.test(value) && maxDp.test(value))) {
       setAmount(value);
       validateAmountInput(value);
     }

--- a/apps/web/src/components/BridgeForm.tsx
+++ b/apps/web/src/components/BridgeForm.tsx
@@ -140,10 +140,13 @@ export default function BridgeForm({
   };
 
   const onInputChange = (value: string): void => {
-    // regex to allow only number
-    const re = /^\d*\.?\d*$/;
-    const maxDp = /^\d*(\.\d{0,6})?$/;
-    if (value === "" || (re.test(value) && maxDp.test(value))) {
+    const numberOnlyRegex = /^\d*\.?\d*$/; // regex to allow only number
+    const maxDpRegex = /^\d*(\.\d{0,6})?$/; // regex to allow only max of 6 dp
+
+    if (
+      value === "" ||
+      (numberOnlyRegex.test(value) && maxDpRegex.test(value))
+    ) {
       setAmount(value);
       validateAmountInput(value);
     }

--- a/apps/web/src/components/erc-transfer/StepLastClaim.tsx
+++ b/apps/web/src/components/erc-transfer/StepLastClaim.tsx
@@ -46,7 +46,7 @@ export default function StepLastClaim({
     functionName: "claimFund",
     args: [
       data.to.address,
-      utils.parseEther(amountLessFee.toString()),
+      utils.parseEther(amountLessFee.toFixed()),
       signedClaim.nonce,
       signedClaim.deadline,
       tokenAddress,

--- a/apps/web/src/store/defichain.tsx
+++ b/apps/web/src/store/defichain.tsx
@@ -67,7 +67,7 @@ export const bridgeApi = createApi({
           symbol,
         },
       }),
-      extraOptions: { maxRetries: 3 },
+      extraOptions: { maxRetries: 0 },
     }),
     getAddressDetail: builder.mutation<AddressDetails, any>({
       query: ({ baseUrl, address }) => ({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- [x] Changing toString -> toFixed because toString() transforms BigNumber to scientific notation
- [x] Add maxRetries:0 on  /verify won't keep on retrying if there's an error
- [x] Add 6 max dp on UI
- [ ] Add 6 max dp on API (will do this in a separate PR)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #575

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
