### PR TITLE
fix(server): prevent creation of defichain private keys if it's not 2…

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,7 +18,7 @@
     "test:unit": "jest --selectProjects test:unit",
     "test:i9n": "jest --selectProjects test:i9n",
     "test:e2e": "jest --selectProjects test:e2e",
-    "docker:pull": "docker pull ghcr.io/jellyfishsdk/whale-api:3.29.0 && docker pull ghcr.io/jellyfishsdk/playground-api:3.29.1 && docker pull defi/defichain:3.2.6 && docker pull postgres:14.6-alpine"
+    "docker:pull": "docker pull ghcr.io/jellyfishsdk/whale-api:3.29.1 && docker pull ghcr.io/jellyfishsdk/playground-api:3.29.1 && docker pull defi/defichain:3.2.6 && docker pull postgres:15.2-alpine"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/apps/server/src/defichain/providers/WhaleWalletProvider.ts
+++ b/apps/server/src/defichain/providers/WhaleWalletProvider.ts
@@ -18,7 +18,11 @@ export class WhaleWalletProvider {
 
   createWallet(index: number = 2): WhaleWalletAccount {
     const mnemonic = this.configService.getOrThrow<string>(`defichain.key`);
-    const data = this.toData(mnemonic.split(' '), this.network);
+    const keys = mnemonic.split(' ');
+    if (keys.length < 24) {
+      throw new Error('Invalid DeFiChain private keys!');
+    }
+    const data = this.toData(keys, this.network);
     const provider = this.initProvider(data, this.network);
     return this.initJellyfishWallet(provider, this.network).get(index);
   }

--- a/apps/server/src/defichain/providers/WhaleWalletProvider.ts
+++ b/apps/server/src/defichain/providers/WhaleWalletProvider.ts
@@ -1,5 +1,9 @@
 import { JellyfishWallet, WalletHdNode, WalletHdNodeProvider } from '@defichain/jellyfish-wallet';
-import { MnemonicHdNodeProvider, MnemonicProviderData } from '@defichain/jellyfish-wallet-mnemonic';
+import {
+  MnemonicHdNodeProvider,
+  MnemonicProviderData,
+  validateMnemonicSentence,
+} from '@defichain/jellyfish-wallet-mnemonic';
 import { WhaleWalletAccount, WhaleWalletAccountProvider } from '@defichain/whale-api-wallet';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -18,11 +22,10 @@ export class WhaleWalletProvider {
 
   createWallet(index: number = 2): WhaleWalletAccount {
     const mnemonic = this.configService.getOrThrow<string>(`defichain.key`);
-    const keys = mnemonic.split(' ');
-    if (keys.length < 24) {
+    if (!validateMnemonicSentence(mnemonic)) {
       throw new Error('Invalid DeFiChain private keys!');
     }
-    const data = this.toData(keys, this.network);
+    const data = this.toData(mnemonic.split(' '), this.network);
     const provider = this.initProvider(data, this.network);
     return this.initJellyfishWallet(provider, this.network).get(index);
   }

--- a/apps/server/test-i9n/ethereum/signClaims.i9n.ts
+++ b/apps/server/test-i9n/ethereum/signClaims.i9n.ts
@@ -11,6 +11,7 @@ import {
 import { WhaleWalletService } from '../../src/defichain/services/WhaleWalletService';
 import { EVMTransactionConfirmerService } from '../../src/ethereum/services/EVMTransactionConfirmerService';
 import { PrismaService } from '../../src/PrismaService';
+import { StartedDeFiChainStubContainer } from '../defichain/containers/DeFiChainStubContainer';
 import { sleep } from '../helper/sleep';
 import { BridgeContractFixture } from '../testing/BridgeContractFixture';
 import { BridgeServerTestingApp } from '../testing/BridgeServerTestingApp';
@@ -44,6 +45,7 @@ describe('Sign Claims Tests', () => {
     testing = new BridgeServerTestingApp(
       TestingModule.register(
         buildTestConfig({
+          defichain: { key: StartedDeFiChainStubContainer.LOCAL_MNEMONIC },
           startedHardhatContainer,
           testnet: {
             bridgeContractAddress: bridgeContract.address,

--- a/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
+++ b/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
@@ -10,6 +10,7 @@ import {
 } from 'smartcontracts';
 
 import { PrismaService } from '../../src/PrismaService';
+import { StartedDeFiChainStubContainer } from '../defichain/containers/DeFiChainStubContainer';
 import { BridgeContractFixture } from '../testing/BridgeContractFixture';
 import { BridgeServerTestingApp } from '../testing/BridgeServerTestingApp';
 import { buildTestConfig, TestingModule } from '../testing/TestingModule';
@@ -40,6 +41,7 @@ describe('Bridge Service Integration Tests', () => {
     testing = new BridgeServerTestingApp(
       TestingModule.register(
         buildTestConfig({
+          defichain: { key: StartedDeFiChainStubContainer.LOCAL_MNEMONIC },
           startedHardhatContainer,
           testnet: { bridgeContractAddress: bridgeContract.address },
           startedPostgresContainer,

--- a/apps/server/test-i9n/testing/HealthService.i9n.ts
+++ b/apps/server/test-i9n/testing/HealthService.i9n.ts
@@ -1,5 +1,6 @@
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@birthdayresearch/sticky-testcontainers';
 
+import { StartedDeFiChainStubContainer } from '../defichain/containers/DeFiChainStubContainer';
 import { BridgeServerTestingApp } from './BridgeServerTestingApp';
 import { buildTestConfig, TestingModule } from './TestingModule';
 
@@ -13,6 +14,7 @@ describe('Health Service Test', () => {
     testing = new BridgeServerTestingApp(
       TestingModule.register(
         buildTestConfig({
+          defichain: { key: StartedDeFiChainStubContainer.LOCAL_MNEMONIC },
           startedPostgresContainer,
         }),
       ),

--- a/apps/server/test-i9n/testing/VersionService.i9n.ts
+++ b/apps/server/test-i9n/testing/VersionService.i9n.ts
@@ -1,6 +1,7 @@
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@birthdayresearch/sticky-testcontainers';
 import { ConfigService } from '@nestjs/config';
 
+import { StartedDeFiChainStubContainer } from '../defichain/containers/DeFiChainStubContainer';
 import { BridgeServerTestingApp } from './BridgeServerTestingApp';
 import { buildTestConfig, TestingModule } from './TestingModule';
 
@@ -15,6 +16,7 @@ describe('Version Service Test', () => {
     testing = new BridgeServerTestingApp(
       TestingModule.register(
         buildTestConfig({
+          defichain: { key: StartedDeFiChainStubContainer.LOCAL_MNEMONIC },
           startedPostgresContainer,
         }),
       ),


### PR DESCRIPTION
…4 words

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
The methods to generate a DeFiChain wallet accepts a string. This string can be anything even if it's not a valid 24 mnemonic words. This will prevent that to make sure that even if it's not set correctly on Env Variables, it would still work.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
