### PR TITLE
fix(ui-ux): fixed getBalance bug in retry claim

### DIFF
--- a/apps/web/src/components/BridgeForm.tsx
+++ b/apps/web/src/components/BridgeForm.tsx
@@ -499,7 +499,7 @@ export default function BridgeForm({
             />
           </div>
         )}
-        {isBalanceInsufficient && (
+        {isBalanceInsufficient && !hasPendingTxn && (
           <div className={clsx("pt-3", warningTextStyle)}>
             Unable to process transaction. <div>Please try again later</div>
           </div>

--- a/apps/web/src/components/WalletAddressInput.tsx
+++ b/apps/web/src/components/WalletAddressInput.tsx
@@ -52,7 +52,7 @@ function AddressWithVerifiedBadge({
         isLg
           ? "after:-bottom-1 after:ml-2 after:content-[url('/verified-24x24.svg')]"
           : "after:ml-1 after:content-[url('/verified-20x20.svg')]",
-        isPrimary ? "text-sm lg:text-xl" : "text-sm"
+        isPrimary ? "text-sm lg:text-base" : "text-sm"
       )}
       onClick={() => onClick()}
       onKeyDown={() => {}}

--- a/apps/web/src/components/erc-transfer/StepLastClaim.tsx
+++ b/apps/web/src/components/erc-transfer/StepLastClaim.tsx
@@ -21,7 +21,8 @@ import useTransferFee from "@hooks/useTransferFee";
 
 const CLAIM_INPUT_ERROR =
   "Check your connection and try again. If the error persists get in touch with us.";
-
+const INSUFFICIENT_FUND_ERROR =
+  "Quantum's servers are currently at capacity. We are unable to process transactions at this time, please try again in a few hours to claim your tokens.";
 export default function StepLastClaim({
   data,
   signedClaim,
@@ -74,17 +75,33 @@ export default function StepLastClaim({
     onSettled: () => setShowLoader(false),
   });
 
-  const { balanceAmount } = useCheckBalance(data.to.tokenSymbol);
-  const isBalanceInsufficient = data.to.amount.isGreaterThan(
-    new BigNumber(balanceAmount)
-  );
+  const { getBalance } = useCheckBalance();
+  const isSufficientBalance = (balance): boolean =>
+    new BigNumber(balance).isGreaterThan(data.to.amount);
+  const [isBalanceSufficient, setIsBalanceSufficient] = useState(false);
+
+  async function checkBalance() {
+    const balance = await getBalance(data.to.tokenSymbol);
+    const isSufficient = isSufficientBalance(balance);
+    if (!isSufficient) {
+      setError(INSUFFICIENT_FUND_ERROR);
+    }
+    setIsBalanceSufficient(isSufficient);
+  }
+
+  useEffect(() => {
+    checkBalance();
+  }, []);
 
   const handleOnClaim = async () => {
     setError(undefined);
     setShowLoader(true);
     if (!write) {
-      setTimeout(() => {
-        setError(CLAIM_INPUT_ERROR);
+      checkBalance();
+      setTimeout(async () => {
+        if (isBalanceSufficient) {
+          setError(CLAIM_INPUT_ERROR);
+        }
         setShowLoader(false);
       }, 500);
       return;
@@ -103,14 +120,6 @@ export default function StepLastClaim({
   useEffect(() => {
     setError(writeClaimTxnError?.message ?? claimTxnError?.message);
   }, [writeClaimTxnError, claimTxnError]);
-
-  useEffect(() => {
-    if (error && isBalanceInsufficient) {
-      setError(
-        "Quantum's servers are currently at capacity. We are unable to process transactions at this time, please try again in a few hours to claim your tokens."
-      );
-    }
-  }, [error, isBalanceInsufficient]);
 
   const statusMessage = {
     title: isClaimInProgress ? "Processing" : "Waiting for confirmation",

--- a/apps/web/src/components/erc-transfer/StepTwoSendConfirmation.tsx
+++ b/apps/web/src/components/erc-transfer/StepTwoSendConfirmation.tsx
@@ -11,21 +11,10 @@ import AddressError from "@components/commons/AddressError";
 import { useStorageContext } from "@contexts/StorageContext";
 import BigNumber from "bignumber.js";
 import AlertInfoMessage from "@components/commons/AlertInfoMessage";
+import debounce from "@utils/debounce";
 import { DFC_TO_ERC_RESET_FORM_TIME_LIMIT } from "../../constants";
 import QrAddress from "../QrAddress";
 import TimeLimitCounter from "./TimeLimitCounter";
-
-function debounce(func, wait) {
-  let timeout;
-  return (...args) => {
-    const context = this;
-    if (timeout) clearTimeout(timeout);
-    timeout = setTimeout(() => {
-      timeout = null;
-      func.apply(context, args);
-    }, wait);
-  };
-}
 
 function getTimeDifference(createdAt?: Date): number {
   if (createdAt) {

--- a/apps/web/src/hooks/useCheckBalance.ts
+++ b/apps/web/src/hooks/useCheckBalance.ts
@@ -1,47 +1,22 @@
-import Logging from "@api/logging";
 import { useNetworkContext } from "@contexts/NetworkContext";
-import { useNetworkEnvironmentContext } from "@contexts/NetworkEnvironmentContext";
 import { useBalanceDfcMutation, useBalanceEvmMutation } from "@store/index";
-import { useEffect, useState } from "react";
 import { Network } from "types";
 
-export default function useCheckBalance(symbol: string) {
-  const [balanceAmount, setBalanceAmount] = useState<string>("0");
-
+export default function useCheckBalance() {
   const [balanceEvm] = useBalanceEvmMutation();
   const [balanceDfc] = useBalanceDfcMutation();
 
-  const { selectedNetworkA, selectedTokensA } = useNetworkContext();
-  const { networkEnv } = useNetworkEnvironmentContext();
-
+  const { selectedNetworkA } = useNetworkContext();
   /**
    * When sending from EVM -> DFC, check that DFC wallet has enough balance;
    * When sending from DFC -> EVM, check that EVM wallet has enough balance;
    */
-  const isSendingFromEvm = selectedNetworkA.name === Network.Ethereum;
-
-  useEffect(() => {
-    async function checkBalance() {
-      try {
-        let balance;
-        if (isSendingFromEvm) {
-          balance = await balanceDfc({
-            tokenSymbol: symbol,
-          }).unwrap();
-        } else {
-          balance = await balanceEvm({
-            tokenSymbol: symbol,
-          }).unwrap();
-        }
-
-        setBalanceAmount(balance);
-      } catch (e) {
-        Logging.error(e);
-      }
-    }
-
-    checkBalance();
-  }, [selectedNetworkA, selectedTokensA, networkEnv]);
-
-  return { balanceAmount };
+  async function getBalance(tokenSymbol: string): Promise<string> {
+    const balance =
+      selectedNetworkA.name === Network.Ethereum
+        ? await balanceDfc({ tokenSymbol }).unwrap()
+        : await balanceEvm({ tokenSymbol }).unwrap();
+    return balance;
+  }
+  return { getBalance };
 }

--- a/apps/web/src/utils/debounce.ts
+++ b/apps/web/src/utils/debounce.ts
@@ -1,0 +1,11 @@
+export default function debounce(func, wait) {
+  let timeout;
+  return (...args) => {
+    const context = this;
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      timeout = null;
+      func.apply(context, args);
+    }, wait);
+  };
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Issue: 
1. Landing page : In case of in-progress txn when user reloads the page (specific to `DFC => EVM` flow) there are multiple api calls to fetch balance for `BTC` and `WBTC` tokens. (this happens because we set initial flow as `EVM => DFC` and when we read localstorage data of pending txn then we get `DFC => EVM` flow, i.e. state change). In this case if 1st api call get delayed then wrong balance value will get set. (check attachment)
<img src="https://user-images.githubusercontent.com/53080940/222715830-1043e649-be22-4caa-be91-69ff2f716c20.png"  width="70%"/>


2. Claim fund: Retry button doesn't send the request for balance check when we don't have funds at Hot wallet


In this PR we solved
1. Created Object in place of string balance variable to map diff balance values 
2. Added get balance func on retry button
3. font size fix #615

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #644 

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
